### PR TITLE
Fix for StructuredClone not found

### DIFF
--- a/test/common/mock-utils.ts
+++ b/test/common/mock-utils.ts
@@ -73,7 +73,7 @@ export function mockQueueMessageContent(permissionResolve: boolean = true) {
     jest.spyOn(QueueMessageContent, "from")
         .mockImplementation((json: any) => {
             var test: QueueMessageContent = new QueueMessageContent();
-            test = structuredClone(json);
+            test = JSON.parse(JSON.stringify(json));
             //This is due to not able to mock Prop() behaviour 
             test.tdeiRecordId = json.tdei_record_id;
             test.userId = json.user_id;


### PR DESCRIPTION
Fix for structuredClone not found, as it is supported in higher version of node , changed the logic to alternative approach